### PR TITLE
Allow URLs to contain tilde characters

### DIFF
--- a/main.js
+++ b/main.js
@@ -476,7 +476,7 @@ function formatEmotes(text, emotes) {
 }
 
 function formatLinks(text, originalText) {
-	var urlRegex = /(https?:\/\/)?(www\.)?([0-9a-zA-Z-_\.]+\.[0-9a-zA-Z]+\/)([0-9a-zA-Z-_#=\/\.\?\|]+)?/g;
+	var urlRegex = /(https?:\/\/)?(www\.)?([0-9a-zA-Z-_\.]+\.[0-9a-zA-Z]+\/)([0-9a-zA-Z-_#=\/\.\?\|\~]+)?/g;
 	var match;
 	while ((match = urlRegex.exec(originalText)) !== null) {
 		var urlText = url = match[0];


### PR DESCRIPTION
Tilde (~) is a perfectly valid character in a URL, and is frequently used to indicate a user's home directory. Allow it in the regexp that finds URLs to link or include as images.