### PR TITLE
help node was catching the hide/show events intended for the subfield

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,8 +109,10 @@
         </div>
         <div>
           <label><input type="checkbox" id="settings-inline-images"/> Show any images linked to by users</label>
-          <span class="help" title="More information" data-title="Load the images linked to by other users in chat. Links must end with a known image extension or must point to Giphy or Imgur."></span>
-          <div class="subfield hidden"><label>Maximum image size: <input type="number" size="2" max="80" min="5" id="settings-inline-images-height"/>% of available screen height</label></div>
+          <div class="subfield hidden">
+            <label>Maximum image size: <input type="number" size="2" max="80" min="5" id="settings-inline-images-height"/>% of available screen height</label>
+            <span class="help" title="More information" data-title="Load the images linked to by other users in chat. Links must end with a known image extension or must point to Giphy or Imgur."></span>
+          </div>
         </div>
         <div><label><input type="checkbox" id="settings-unfurl-twitter"/> Unfurl Twitter/X links</label></div>
         <div><label><input type="checkbox" id="settings-unfurl-youtube"/> Unfurl YouTube links</label></div>

--- a/index.html
+++ b/index.html
@@ -109,10 +109,8 @@
         </div>
         <div>
           <label><input type="checkbox" id="settings-inline-images"/> Show any images linked to by users</label>
-          <div class="subfield hidden">
-            <label>Maximum image size: <input type="number" size="2" max="80" min="5" id="settings-inline-images-height"/>% of available screen height</label>
-            <span class="help" title="More information" data-title="Load the images linked to by other users in chat. Links must end with a known image extension or must point to Giphy or Imgur."></span>
-          </div>
+          <span class="help" title="More information" data-title="Load the images linked to by other users in chat. Links must end with a known image extension or must point to Giphy or Imgur."></span>
+          <div class="subfield hidden"><label>Maximum image size: <input type="number" size="2" max="80" min="5" id="settings-inline-images-height"/>% of available screen height</label></div>
         </div>
         <div><label><input type="checkbox" id="settings-unfurl-twitter"/> Unfurl Twitter/X links</label></div>
         <div><label><input type="checkbox" id="settings-unfurl-youtube"/> Unfurl YouTube links</label></div>

--- a/main.js
+++ b/main.js
@@ -131,7 +131,7 @@ var ui = {
 		},
 		messageHandling: {
 			inlineImages: {
-				body: document.getElementById('settings-inline-images').parentNode.nextElementSibling,
+				body: document.getElementById('settings-inline-images').parentNode.nextElementSibling.nextElementSibling,
 				height: document.getElementById('settings-inline-images-height')
 			},
 			timestamps: document.getElementById('settings-timestamps'),


### PR DESCRIPTION
The "image height" suboption for the "show images" option wasn't showing when "show images" was enabled. I reordered the help node to be in the suboption div, like it is elsewhere.